### PR TITLE
Adding replace_android_tokens.sh support for linux

### DIFF
--- a/sample-project/replace_android_tokens.sh
+++ b/sample-project/replace_android_tokens.sh
@@ -1,4 +1,4 @@
-sed -i '' 's/\$PACKAGE_NAME/com.appboy.hellocordova/g' platforms/android/src/com/appboy/AppboyBroadcastReceiver.java
-sed -i '' 's/\$APPBOY_API_KEY/7ef72382-b92f-4258-9be9-9e19e92f3bf1/g' platforms/android/res/values/appboy.xml
-sed -i '' 's/\$APPBOY_PUSH_REGISTRATION_ENABLED/true/g' platforms/android/res/values/appboy.xml
-sed -i '' 's/\$APPBOY_GCM_SENDER_ID/901477453852/g' platforms/android/res/values/appboy.xml
+sed -i -e 's/\$PACKAGE_NAME/com.appboy.hellocordova/g' platforms/android/src/com/appboy/AppboyBroadcastReceiver.java
+sed -i -e 's/\$APPBOY_API_KEY/7ef72382-b92f-4258-9be9-9e19e92f3bf1/g' platforms/android/res/values/appboy.xml
+sed -i -e 's/\$APPBOY_PUSH_REGISTRATION_ENABLED/true/g' platforms/android/res/values/appboy.xml
+sed -i -e 's/\$APPBOY_GCM_SENDER_ID/901477453852/g' platforms/android/res/values/appboy.xml


### PR DESCRIPTION
Original sed usage was compatible with Mac OS X and not linux. New solution works with both platforms.

Here's a post outlining the differences: http://unix.stackexchange.com/questions/13711/differences-between-sed-on-mac-osx-and-other-standard-sed