### PR TITLE
Added functionality to manually trigger for push registration on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,11 @@
 Effective marketing automation is an essential part of successfully scaling and managing your business. Braze empowers you to build better customer relationships through a seamless, multi-channel approach that addresses all aspects of the user life cycle. Braze helps you engage your users on an ongoing basis. View the following resources for details and we'll have you up and running in no time!
 
 See our [Technical Documentation for Android](https://www.braze.com/docs/developer_guide/platform_integration_guides/cordova/android_and_fireos/initial_sdk_setup/) and [Technical Documentation for iOS](https://www.braze.com/docs/developer_guide/platform_integration_guides/cordova/ios/initial_sdk_setup/) for instructions on integrating Braze into your Cordova app.
+
+
+## Reason for Fork
+
+The original repo does not allow us to promptForPush at a specific trigger point within the app for iOS. We did not want to ask the user for prompt permission right on app open. 
+The repo was forked in order to create a function called promptForPush() for iOS.
+
+A [pull request](https://github.com/Appboy/appboy-cordova-sdk/pull/68) has been submitted to the original repo in case they decide to merge it in, which would allow us to switch back to the original repo and not worry about having to maintain this one.

--- a/src/ios/AppboyPlugin.h
+++ b/src/ios/AppboyPlugin.h
@@ -8,6 +8,7 @@
 - (void) logPurchase:(CDVInvokedUrlCommand *)command;
 - (void) disableSdk:(CDVInvokedUrlCommand *)command;
 - (void) enableSdk:(CDVInvokedUrlCommand *)command;
+- (void) promptForPush:(CDVInvokedUrlCommand *)command;
 - (void) wipeData:(CDVInvokedUrlCommand *)command;
 - (void) requestImmediateDataFlush:(CDVInvokedUrlCommand *)command;
 - (void) getDeviceId:(CDVInvokedUrlCommand *)command;

--- a/src/ios/AppboyPlugin.m
+++ b/src/ios/AppboyPlugin.m
@@ -103,6 +103,39 @@
 }
 
 /*-------Appboy.h-------*/
+- (void)promptForPush:(CDVInvokedUrlCommand *)command {
+  UIUserNotificationType notificationSettingTypes = (UIUserNotificationTypeBadge | UIUserNotificationTypeAlert | UIUserNotificationTypeSound);
+    if (floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_9_x_Max) {
+      UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+      // If the delegate hasn't been set yet, set it here in the plugin
+      // if (center.delegate == nil) {
+      //   center.delegate = [UIApplication sharedApplication].delegate;
+      // }
+      UNAuthorizationOptions options = UNAuthorizationOptionAlert | UNAuthorizationOptionSound | UNAuthorizationOptionBadge;
+      if (@available(iOS 12.0, *)) {
+        // options = options | UNAuthorizationOptionProvisional;
+      }
+      [center requestAuthorizationWithOptions:options
+                            completionHandler:^(BOOL granted, NSError *_Nullable error) {
+                              NSLog(@"Permission granted.");
+                              NSLog(@"Permission granted.");
+                              [[Appboy sharedInstance] pushAuthorizationFromUserNotificationCenter:granted];
+                            }];
+      [[UIApplication sharedApplication] registerForRemoteNotifications];
+      NSString* callbackId = command.callbackId;
+      NSString* packageName = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleIdentifier"];
+      CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:packageName];
+      [self.commandDelegate sendPluginResult:pluginResult callbackId:callbackId];
+    } else if (floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_7_1) {
+      UIUserNotificationSettings *settings = [UIUserNotificationSettings settingsForTypes:notificationSettingTypes categories:nil];
+      [[UIApplication sharedApplication] registerForRemoteNotifications];
+      [[UIApplication sharedApplication] registerUserNotificationSettings:settings];
+    } else {
+      [[UIApplication sharedApplication] registerForRemoteNotificationTypes: notificationSettingTypes];
+    }
+  }
+
+
 - (void)changeUser:(CDVInvokedUrlCommand *)command {
   NSString *userId = [command argumentAtIndex:0 withDefault:nil];
   [[Appboy sharedInstance] changeUser:userId];

--- a/www/AppboyPlugin.js
+++ b/www/AppboyPlugin.js
@@ -40,6 +40,14 @@ AppboyPlugin.prototype.changeUser = function (userId) {
 }
 
 /**
+* Prompts for push
+*/
+AppboyPlugin.prototype.promptForPush = function () {
+	cordova.exec(null, null, "AppboyPlugin", "promptForPush");
+  }
+
+
+/**
 * ** ANDROID ONLY**
 *
 * Registers the device as eligible to receive push notifications from Appboy.


### PR DESCRIPTION
Added functionality to prompt for notifications on a custom trigger point for iOS, rather than on just app open.

Using ideas from: https://github.com/Appboy/appboy-cordova-sdk/issues/20. This fixes mentioned issue as well.