### PR TITLE
Add push notification methods & update delegate re foreground notification (iOS only)

### DIFF
--- a/src/ios/AppDelegate+Appboy.m
+++ b/src/ios/AppDelegate+Appboy.m
@@ -129,4 +129,14 @@
         completionHandler(UNNotificationPresentationOptionAlert);
     }
 }
+
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)(void))completionHandler {
+  [[Appboy sharedInstance] userNotificationCenter:center didReceiveNotificationResponse:response withCompletionHandler:completionHandler];
+  NSLog(@"Application delegate method userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler: is called with user info: %@", response.notification.request.content.userInfo);
+
+  if ([ABKPushUtils isAppboyUserNotification:response]) {
+    [UIApplication sharedApplication].applicationIconBadgeNumber = 0;
+    NSLog(@"User notification was sent from Braze, clearing badge number.");
+  }
+}
 @end

--- a/src/ios/AppboyPlugin.h
+++ b/src/ios/AppboyPlugin.h
@@ -11,6 +11,8 @@
 - (void) wipeData:(CDVInvokedUrlCommand *)command;
 - (void) requestImmediateDataFlush:(CDVInvokedUrlCommand *)command;
 - (void) getDeviceId:(CDVInvokedUrlCommand *)command;
+- (void) hasUserAnsweredNotificationPrompt:(CDVInvokedUrlCommand *)command;
+- (void) registerPushNotification:(CDVInvokedUrlCommand *)command;
 
 /*-------ABKUser.h-------*/
 - (void) setFirstName:(CDVInvokedUrlCommand *)command;

--- a/src/ios/AppboyPlugin.m
+++ b/src/ios/AppboyPlugin.m
@@ -139,6 +139,32 @@
   [[Appboy sharedInstance] requestImmediateDataFlush];
 }
 
+- (void)hasUserAnsweredNotificationPrompt:(CDVInvokedUrlCommand *)command {
+    UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+    [center getNotificationSettingsWithCompletionHandler:^(UNNotificationSettings * _Nonnull settings) {
+        BOOL result = (settings.authorizationStatus != UNAuthorizationStatusNotDetermined);
+        [self sendCordovaSuccessPluginResultWithBool:result andCommand:command];
+    }];
+}
+
+- (void)registerPushNotification:(CDVInvokedUrlCommand *)command {
+    UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+    if (center.delegate == nil) {
+      center.delegate = [UIApplication sharedApplication].delegate;
+    }
+
+    UNAuthorizationOptions options = UNAuthorizationOptionAlert | UNAuthorizationOptionSound | UNAuthorizationOptionBadge;
+    if (![self.disableUNAuthorizationOptionProvisional isEqualToString:@"YES"] && @available(iOS 12.0, *)) {
+      options = options | UNAuthorizationOptionProvisional;
+    }
+    [center requestAuthorizationWithOptions:options completionHandler:^(BOOL granted, NSError * _Nullable error) {
+      [[Appboy sharedInstance] pushAuthorizationFromUserNotificationCenter:granted];
+      [self sendCordovaSuccessPluginResultWithBool:granted andCommand:command];
+    }];
+    [[UIApplication sharedApplication] registerForRemoteNotifications];
+    [center setNotificationCategories:[ABKPushUtils getAppboyUNNotificationCategorySet]];
+}
+
 /*-------ABKUser.h-------*/
 - (void) setFirstName:(CDVInvokedUrlCommand *)command {
   NSString *firstName = [command argumentAtIndex:0 withDefault:nil];
@@ -564,6 +590,12 @@
 - (void) sendCordovaSuccessPluginResultWithInt:(NSUInteger)resultMessage andCommand:(CDVInvokedUrlCommand *)command {
   CDVPluginResult *pluginResult = nil;
   pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsInt:resultMessage];
+  [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
+- (void) sendCordovaSuccessPluginResultWithBool:(BOOL)resultMessage andCommand:(CDVInvokedUrlCommand *)command {
+  CDVPluginResult *pluginResult = nil;
+  pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:resultMessage];
   [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 

--- a/www/AppboyPlugin.js
+++ b/www/AppboyPlugin.js
@@ -409,6 +409,25 @@ AppboyPlugin.prototype.logContentCardDismissed = function (cardId) {
 }
 
 /**
+ * ** iOS ONLY **
+ *
+ * Gets a boolean indicating if the user received and answered (allowing or not) the prompt to allow notifications
+ */
+AppboyPlugin.prototype.hasUserAnsweredNotificationPrompt = function (successCallback) {
+	cordova.exec(successCallback, null, "AppboyPlugin", "hasUserAnsweredNotificationPrompt");
+}
+
+/**
+ * ** iOS ONLY **
+ *
+ * If the user was never prompted, it will prompt for permission to send push notifications.
+ * This method needs to be called each time when the app starts after the user has given permission, to ensure the token in Braze is up to date.
+ */
+AppboyPlugin.prototype.registerPushNotification = function (successCallback) {
+	cordova.exec(successCallback, null, "AppboyPlugin", "registerPushNotification");
+}
+
+/**
  * Sets the language for a user. Language Strings should be valid ISO 639-1 language codes. See loc.gov/standards/iso639-2/php/code_list.php.
  */
 AppboyPlugin.prototype.setLanguage = function (language) {


### PR DESCRIPTION
This will implement the following changes:

1. Add an iOS only method -- hasUserAnsweredNotificationPrompt -- that gets a boolean indicating if the user received and answered (allowing or not) the prompt to allow notifications
2. Add an iOS only method -- registerPushNotification -- for prompting for permission to send push notification if the user was never prompted with it
3. Update delegate method -- userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler -- to clear the 'applicationIconBadgeNumber' once user notification was sent from Braze. This ensures that foreground notifications are being delivered