### PR TITLE
Handle error in AppboyPlugin getJsonFromExtras when extras is a nil value

### DIFF
--- a/src/ios/AppboyPlugin.m
+++ b/src/ios/AppboyPlugin.m
@@ -555,6 +555,11 @@
 }
 
 + (NSString *) getJsonFromExtras:(NSDictionary *)extras {
+  if (!extras) {
+    NSLog(@"Got an error in getJsonFromExtras: extras is nil");
+    return @"{}";
+  }
+
   NSError *error;
   NSData *jsonData = [NSJSONSerialization dataWithJSONObject:extras
                                                      options:0


### PR DESCRIPTION
In our usage of Braze Cordova SDK on iOS, we sometimes get an error when publishing content cards to users that causes the app to crash.

We published this content card: https://dashboard-05.braze.com/engagement/campaigns/636c0dd211182453fd061ce2/6102e56c88de322c339d0881?locale=en&campaignName=Nov%20%2722%20Referrals%20Content%20Card%20Testing&page=-2

And noticed a spike in our app crash in our firebase dashboard:
<img width="1166" alt="Screen Shot 2022-11-10 at 3 59 17 PM" src="https://user-images.githubusercontent.com/2723718/201214724-727dc371-16bd-46dc-ae0e-39be024a34dd.png">

With the full the stacktrace of the crashes pointing to this `[AppboyPlugin getJsonFromExtras]` method:
```
Fatal Exception: NSInvalidArgumentException
*** +[NSJSONSerialization dataWithJSONObject:options:error:]: value parameter is nil
Fatal Exception: NSInvalidArgumentException
0  CoreFoundation                 0x9e88 __exceptionPreprocess
1  libobjc.A.dylib                0x178d8 objc_exception_throw
2  Foundation                     0x51140 +[NSData(NSData) dataWithBytesNoCopy:length:freeWhenDone:]
3  Found                          0x6d038 +[AppboyPlugin getJsonFromExtras:] + 555 (AppboyPlugin.m:555)
4  Found                          0x6cb88 +[AppboyPlugin RCTFormatContentCard:] + 522 (AppboyPlugin.m:522)
5  Found                          0x6c664 __41-[AppboyPlugin getContentCardsFromCache:]_block_invoke + 490 (AppboyPlugin.m:490)
6  CoreFoundation                 0xa3a0 __NSARRAY_IS_CALLING_OUT_TO_A_BLOCK__
7  CoreFoundation                 0x93d0c -[__NSArrayI_Transfer enumerateObjectsWithOptions:usingBlock:]
8  Found                          0x6c5f0 -[AppboyPlugin getContentCardsFromCache:] + 493 (AppboyPlugin.m:493)
9  CoreFoundation                 0x373f0 __CFNOTIFICATIONCENTER_IS_CALLING_OUT_TO_AN_OBSERVER__
10 CoreFoundation                 0xde474 ___CFXRegistrationPost_block_invoke
11 CoreFoundation                 0xc1724 _CFXRegistrationPost
12 CoreFoundation                 0x4ba08 _CFXNotificationPost
13 Foundation                     0x5cffc -[NSNotificationCenter postNotificationName:object:userInfo:]
14 Appboy_iOS_SDK                 0x997a8 (Missing UUID b57e560c2b583ccbad1f8cc05d5f5001)
15 Appboy_iOS_SDK                 0x995b8 (Missing UUID b57e560c2b583ccbad1f8cc05d5f5001)
16 CoreFoundation                 0x37404 __CFNOTIFICATIONCENTER_IS_CALLING_OUT_TO_AN_OBSERVER__
17 CoreFoundation                 0xde474 ___CFXRegistrationPost_block_invoke
18 CoreFoundation                 0xc1724 _CFXRegistrationPost
19 CoreFoundation                 0x4ba08 _CFXNotificationPost
20 Foundation                     0x5cffc -[NSNotificationCenter postNotificationName:object:userInfo:]
21 Appboy_iOS_SDK                 0x31978 (Missing UUID b57e560c2b583ccbad1f8cc05d5f5001)
22 Appboy_iOS_SDK                 0xa12e4 (Missing UUID b57e560c2b583ccbad1f8cc05d5f5001)
23 Appboy_iOS_SDK                 0xa23d0 (Missing UUID b57e560c2b583ccbad1f8cc05d5f5001)
24 libdispatch.dylib              0x24b4 _dispatch_call_block_and_release
25 libdispatch.dylib              0x3fdc _dispatch_client_callout
26 libdispatch.dylib              0x127f4 _dispatch_main_queue_drain
27 libdispatch.dylib              0x12444 _dispatch_main_queue_callback_4CF
28 CoreFoundation                 0x9a6f8 __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__
29 CoreFoundation                 0x7c058 __CFRunLoopRun
30 CoreFoundation                 0x80ed4 CFRunLoopRunSpecific
31 GraphicsServices               0x1368 GSEventRunModal
32 UIKitCore                      0x3a23d0 -[UIApplication _run]
33 UIKitCore                      0x3a2034 UIApplicationMain
34 Found                          0x615c main + 32 (main.m:32)
35 ???                            0x1ee220960 (Missing)
```

We cross referenced the user ids in our analytics dashboards of users who had been sent this specific content card today and the user ids who saw the crashing issue and confirmed everyone seeing this exception was a subset of users that were sent this content card.

After stopping the content card campaign in Braze and selecting the "Remove card after the next sync (e.g. session start)", we were able to see the crashes stopped happening around 2022-11-10 9:11 AM UTC.

There might still be an issue in the braze apis that is causing content cards to send with the extras field as nil instead of an empty object, but checking if this value is nil here and returning an empty json object should stop the app from crashing in this scenario for now.